### PR TITLE
Add required fields in create issue api and more tests

### DIFF
--- a/src/issues/factories.py
+++ b/src/issues/factories.py
@@ -13,6 +13,7 @@ from issues.models import (
     Component,
     Issue,
     IssueStatus,
+    IssueSubType,
     IssueType,
     SubComponent,
 )
@@ -140,6 +141,15 @@ class IssueTypeFactory(DjangoModelFactory):
         model = IssueType
 
     name = factory.Sequence(lambda n: f"Type {n}")
+
+
+class IssueSubTypeFactory(DjangoModelFactory):
+    """Factory for creating IssueSubTypeFactory instances for testing."""
+
+    class Meta:
+        model = IssueSubType
+
+    name = factory.Sequence(lambda n: f"SubType {n}")
 
 
 class ComponentFactory(DjangoModelFactory):

--- a/src/issues/serializers.py
+++ b/src/issues/serializers.py
@@ -203,7 +203,18 @@ class IssueDetailSerializer(serializers.ModelSerializer):
 
 
 class IssueCreateSerializer(serializers.ModelSerializer):
-    citizen = CitizenSerializer()
+    category = serializers.IntegerField(required=True)
+    citizen = CitizenSerializer(required=False)
+    contact_medium = serializers.CharField(required=True)
+    contact_information = serializers.CharField(required=False, allow_null=True)
+    description = serializers.CharField(required=True)
+    intake_date = serializers.DateTimeField(required=True)
+    issue_location = serializers.JSONField(required=True)
+    issue_type = serializers.CharField(required=True)
+    issue_sub_type = serializers.CharField(required=True)
+    ongoing_issue = serializers.BooleanField(required=False, default=False)
+    title = serializers.CharField(required=True)
+    tracking_code = serializers.CharField(required=True)
 
     class Meta:
         model = Issue
@@ -224,13 +235,19 @@ class IssueCreateSerializer(serializers.ModelSerializer):
             'contact_information',
             'ongoing_issue',
             'tracking_code',
-            'status',
-            'category',
-            'issue_type',
-            'administrative_region',
             'intake_date',
             'issue_sub_type',
+            'issue_location',
         ]
+
+    def validate_location_info(self, value):
+        if 'issue_location' not in value:
+            raise serializers.ValidationError("The 'issue_location' key is required within 'location_info'.")
+
+        if 'administrative_id' not in value.get('issue_location', {}):
+            raise serializers.ValidationError("The 'administrative_id' key is required within 'issue_location'.")
+
+        return value
 
     def create(self, validated_data):
         citizen_data = validated_data.pop('citizen')
@@ -242,8 +259,19 @@ class IssueCreateSerializer(serializers.ModelSerializer):
             group_2=citizen_data['group_2'],
         )
         citizen.save()
+        category_data = validated_data.pop('category')
+        issue_type_data = validated_data.pop('issue_type')
+        issue_sub_type_data = validated_data.pop('issue_sub_type')
+        issue_location_data = validated_data.pop('issue_location')
 
-        issue = Issue(citizen_id=citizen.id, **validated_data)
+        issue = Issue(
+            citizen_id=citizen.id,
+            category_id=category_data,
+            issue_type_id=issue_type_data,
+            issue_sub_type_id=issue_sub_type_data,
+            issue_location_id=issue_location_data,
+            **validated_data
+        )
         issue.save()
         return issue
 

--- a/src/issues/tests/integration_tests/test_create_issue_api_view.py
+++ b/src/issues/tests/integration_tests/test_create_issue_api_view.py
@@ -15,6 +15,7 @@ from issues.factories import (
     IssueDepartmentAdministrativeLevelFactory,
     IssueDepartmentFactory,
     IssueStatusFactory,
+    IssueSubTypeFactory,
     IssueTypeFactory,
     SubComponentFactory,
     UserFactory,
@@ -57,6 +58,8 @@ class TestIssueCreateAPIView(APITestCase):
             assigned_escalation_department=self.department_admin_level,
         )
         self.issue_type = IssueTypeFactory(name="Test Issue Type")
+        self.issue_sub_type = IssueSubTypeFactory(name="Test Issue SubType")
+
         self.initial_status = IssueStatusFactory()
         self.component = ComponentFactory()
         self.sub_component = SubComponentFactory()
@@ -66,37 +69,10 @@ class TestIssueCreateAPIView(APITestCase):
         self.citizen = CitizenFactory(age_group=self.age_group, group=self.group_one, group_2=self.group_two)
 
     def test_create_issue_with_valid_data(self):
-        """
-        Tests that an issue can be created with valid data.
-        """
         self.client.force_authenticate(user=self.reporter_user)
 
-        data = {
-            "title": "Test Issue",
-            "description": "This is a test issue.",
-            "status": self.initial_status.pk,
-            "category": self.issue_category.pk,
-            "issue_type": self.issue_type.pk,
-            "administrative_region": self.child_region.pk,
-            "reporter": self.reporter_user.pk,
-            "assignee": self.assignee_user.pk,
-            "citizen": {
-                "name": "Test Citizen",
-                "type": "organization_behalf_someone",
-                "age_group": self.age_group.pk,
-                "group": self.group_one.pk,
-                "group_2": self.group_two.pk,
-            },
-            "component": self.component.pk,
-            "sub_component": self.sub_component.pk,
-            "contact_medium": "channel-alert",
-            "contact_method": None,
-            "contact_information": "aa",
-            "ongoing_issue": True,
-            "tracking_code": "TRACK123",
-        }
+        data = self.__get_valid_data()
 
-        # Use reverse with the app namespace
         url = reverse("issues:create-issue")
         response = self.client.post(url, data=data, format="json")
 
@@ -106,24 +82,6 @@ class TestIssueCreateAPIView(APITestCase):
         self.assertEqual(created_issue.title, "Test Issue")
         self.assertEqual(created_issue.reporter, self.reporter_user)
         self.assertEqual(created_issue.administrative_region, self.child_region)
-
-    def test_create_issue_with_invalid_data(self):
-        """
-        Tests that an issue cannot be created with invalid data.
-        """
-        self.client.force_authenticate(user=self.reporter_user)
-
-        data = {
-            # Missing required fields like 'title'
-            "description": "This is a test issue.",
-        }
-
-        # Use reverse with the app namespace
-        url = reverse("issues:create-issue")
-        response = self.client.post(url, data=data, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(Issue.objects.count(), 0)
 
     def test_create_issue_without_authentication(self):
         """
@@ -145,3 +103,58 @@ class TestIssueCreateAPIView(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(Issue.objects.count(), 0)
+
+    def test_create_issue_with_missing_required_field(self):
+        self.client.force_authenticate(user=self.reporter_user)
+
+        test_cases = [
+            {"expected_error_field": "title"},
+            {"expected_error_field": "description"},
+            {"expected_error_field": "issue_location"},
+            {"expected_error_field": "contact_medium"},
+            {"expected_error_field": "intake_date"},
+            {"expected_error_field": "issue_type"},
+            {"expected_error_field": "issue_sub_type"},
+            {"expected_error_field": "tracking_code"},
+        ]
+        url = reverse("issues:create-issue")
+
+        for case in test_cases:
+            data = self.__get_valid_data()
+            del data[case["expected_error_field"]]
+
+            with self.subTest(msg=f"Testing missing field: {case['expected_error_field']}"):
+                response = self.client.post(url, data=data, format="json")
+
+                self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+                self.assertIn(case["expected_error_field"], response.data['errors'])
+                self.assertEqual(Issue.objects.count(), 0)
+
+    def __get_valid_data(self):
+        return {
+            "title": "Test Issue",
+            "description": "This is a test issue.",
+            "status": self.initial_status.pk,
+            "category": self.issue_category.pk,
+            "issue_type": self.issue_type.pk,
+            "issue_sub_type": self.issue_sub_type.pk,
+            "issue_location": self.child_region.pk,
+            "intake_date": "2011-10-05T14:48:00.000Z",
+            "administrative_region": self.child_region.pk,
+            "reporter": self.reporter_user.pk,
+            "assignee": self.assignee_user.pk,
+            "citizen": {
+                "name": "Test Citizen",
+                "type": "organization_behalf_someone",
+                "age_group": self.age_group.pk,
+                "group": self.group_one.pk,
+                "group_2": self.group_two.pk,
+            },
+            "component": self.component.pk,
+            "sub_component": self.sub_component.pk,
+            "contact_medium": "channel-alert",
+            "contact_method": None,
+            "contact_information": "aa",
+            "ongoing_issue": True,
+            "tracking_code": "TRACK123",
+        }


### PR DESCRIPTION
- [ ] Test Create API call: 

example of sucess payload 
```

{
            "title": "Test Issue",
            "description": "This is a test issue.",
            "status": 1,
            "category": 1,
            "issue_type":1,
            "issue_sub_type":3,
            "issue_location":3,
            "intake_date": "2011-10-05T14:48:00.000Z",
            "administrative_region": 2,
            "reporter": 1,
            "assignee": 1,
            "citizen": {
                "name": "Test Citizen",
                "type": "organization_behalf_someone",
                "age_group": 1,
                "group": 1,
                "group_2": 1
            },
            "component": 1,
            "sub_component": 1,
            "contact_medium": "channel-alert",
            "contact_information": "aa",
            "ongoing_issue": true,
            "tracking_code": "TRACK123"
        }


```